### PR TITLE
Add location in schema

### DIFF
--- a/src/server/schema.js
+++ b/src/server/schema.js
@@ -15,6 +15,7 @@ export const typeDefs = gql`
     contact: Contact
     start: String
     end: String
+    location: String
   }
   
   type Activity {


### PR DESCRIPTION
# Problem
Requirement to complete [question 3](https://github.com/Skedulo/tech-test-frontend/blob/master/src/question-three/INSTRUCTIONS.md): show location from backend server (see [wireframe for Q3](https://www.figma.com/file/K1Z6ZQp2nmFamEsjMEQ6LoBW/Question-three?node-id=1%3A34)), but the Graphql server does not return location. 

# Proposed solution 
[DB.json](https://github.com/Skedulo/tech-test-frontend/blob/master/src/server/db.json) has got a row for `location` inside `job`, we just need to put `location` on the typedef schema.